### PR TITLE
Correct path to SCSS files in watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@ gulp.task('bs-reload', function () {
 */
 gulp.task('default', ['pre-process', 'bs-reload', 'browser-sync'], function(){
   gulp.start('pre-process');
-  gulp.watch('sass/*/*.scss', ['pre-process']);
+  gulp.watch('scss/*/*.scss', ['pre-process']);
   gulp.watch('css/site.min.css', ['bs-reload']);
   gulp.watch(['*.html'], ['bs-reload']);
 });


### PR DESCRIPTION
The directory containing styles was renamed `scss` from `sass`, the path for the watch task was not.

No styles are currently being watched by the `pre-process` task.
