### PR TITLE
Remove duplicate class names from nested-grid example

### DIFF
--- a/examples/nested-grid.html
+++ b/examples/nested-grid.html
@@ -156,8 +156,8 @@
                 <div class="flex">
                 
             
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
                     
 
                 </div>
@@ -176,8 +176,8 @@
                 <div class="flex">
                 
             
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
                     
 
                 </div>
@@ -196,8 +196,8 @@
                 <div class="flex">
                 
             
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
                     
 
                 </div>
@@ -216,8 +216,8 @@
                 <div class="flex">
                 
             
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
-                        <div class="col col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
+                        <div class="col col--6"><div class="demo--content-block"><p>Child column</p></div></div>
                     
 
                 </div>


### PR DESCRIPTION
Removes one redunant "col" from the nested-grid example HTML file.
